### PR TITLE
Change symlink for Chef service binaries to actual RubyGem binary direct...

### DIFF
--- a/recipes/rubygems-install.rb
+++ b/recipes/rubygems-install.rb
@@ -214,7 +214,7 @@ when "init"
     end
 
     link "/usr/sbin/#{svc}" do
-      to "#{node['languages']['ruby']['bin_dir']}/#{svc}"
+      to "#{Gem.bindir}/#{svc}"
     end
 
     service "#{svc}" do


### PR DESCRIPTION
...ory

In Ubuntu 12.04 with Ruby 1.9.3 the RubyGem binaries are installed to a different directory than the Ruby binary. The RubyGem recipe was assuming they were in the same directory.
